### PR TITLE
Poc/secp256k1 cfunction test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
         url = 'https://artifacts.consensys.net/public/maven/maven/'
         content { includeGroupByRegex('tech\\.pegasys(\\..*)?') }
     }
-    //mavenLocal()
+    mavenLocal()
 
     // temporarily using garyschulte:besu-native releases until CI builds all arch and static artifacts
     def garyschulteBesuNative =   ivy {
@@ -164,6 +164,11 @@ graalvmNative {
 // Make nativeCompile depend on extracting the libraries
 tasks.named('nativeCompile') {
     dependsOn 'extractNativeLibs'
+}
+
+// Make build task include native image compilation
+tasks.named('build') {
+    dependsOn tasks.named('nativeCompile')
 }
 
 tasks.withType(JavaCompile) {

--- a/build.gradle
+++ b/build.gradle
@@ -51,18 +51,19 @@ application {
     mainClass = 'org.hyperledger.besu.riscv.poc.NativeImageTestRunner'
 }
 
-// Task to extract native libraries from gnark static JAR
-tasks.register('extractGnarkNativeLibs', Copy) {
-    def gnarkConfig = configurations.runtimeClasspath
-    def gnarkStaticJar = gnarkConfig.files.find { it.name.contains('gnark') && it.name.contains('static') }
+// Task to extract native libraries from static JARs
+tasks.register('extractNativeLibs', Copy) {
+    def config = configurations.runtimeClasspath
+    def staticJars = config.files.findAll { it.name.contains('-static.jar') }
 
-    if (gnarkStaticJar) {
-        from(zipTree(gnarkStaticJar)) {
+    staticJars.each { staticJar ->
+        println "Extracting native libraries from: ${staticJar.name}"
+        from(zipTree(staticJar)) {
             include 'lib/**/*.a'
             include 'lib/**/*.h'
         }
-        into layout.buildDirectory.dir('native-libs')
     }
+    into layout.buildDirectory.dir('native-libs')
 }
 
 // Detect platform for library path, with override for cross-compilation
@@ -120,7 +121,11 @@ graalvmNative {
             def nativeLibDir = layout.buildDirectory.dir("native-libs/lib/${platform}").get().asFile
             buildArgs.add("-H:CLibraryPath=${nativeLibDir.absolutePath}")
 
-            // Link against the gnark static libraries
+            // Add include path for header files
+            // Need to set this early so it's available during query code compilation
+            buildArgs.add("-H:CCompilerOption=-I${nativeLibDir.absolutePath}")
+
+            // Link against the static libraries
             buildArgs.add("-H:NativeLinkerOption=-lgnark_jni")
             buildArgs.add("-H:NativeLinkerOption=-lgnark_eip_196")
             buildArgs.add("-H:NativeLinkerOption=-lgnark_eip_2537")
@@ -157,7 +162,7 @@ graalvmNative {
 
 // Make nativeCompile depend on extracting the libraries
 tasks.named('nativeCompile') {
-    dependsOn 'extractGnarkNativeLibs'
+    dependsOn 'extractNativeLibs'
 }
 
 tasks.withType(JavaCompile) {

--- a/build.gradle
+++ b/build.gradle
@@ -103,11 +103,7 @@ graalvmNative {
             imageName = 'nativeImageTestRunner'
             mainClass = 'org.hyperledger.besu.riscv.poc.NativeImageTestRunner'
 
-            // Use specific GraalVM installation
-            javaLauncher = javaToolchains.launcherFor {
-                languageVersion = JavaLanguageVersion.of(21)
-                vendor = JvmVendorSpec.GRAAL_VM
-            }
+            // Use JAVA_HOME environment variable (GraalVM installation)
 
             buildArgs.add('--verbose')
             buildArgs.add('--no-fallback')
@@ -125,7 +121,12 @@ graalvmNative {
             // Need to set this early so it's available during query code compilation
             buildArgs.add("-H:CCompilerOption=-I${nativeLibDir.absolutePath}")
 
+            // Also try adding as a system include path which might help with angle bracket includes
+            buildArgs.add("-H:CCompilerOption=-isystem")
+            buildArgs.add("-H:CCompilerOption=${nativeLibDir.absolutePath}")
+
             // Link against the static libraries
+            buildArgs.add("-H:NativeLinkerOption=-lsecp256k1")
             buildArgs.add("-H:NativeLinkerOption=-lgnark_jni")
             buildArgs.add("-H:NativeLinkerOption=-lgnark_eip_196")
             buildArgs.add("-H:NativeLinkerOption=-lgnark_eip_2537")

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@ version=25.10.0-alpha
 org.gradle.jvmargs=-Xmx4g
 org.gradle.parallel=true
 org.gradle.caching=true
+besuVersion=25.9.0

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -2,17 +2,26 @@ dependencyManagement {
     imports {
         //mavenBom "org.hyperledger.besu:bom:{$besuVersion}"
         mavenBom "org.hyperledger.besu:bom:25.9.0"
-        mavenBom "org.apache.logging.log4j:log4j-bom:2.24.3"
+        // Removed log4j-bom, using logback instead
     }
+}
+
+configurations.all {
+    exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j2-impl'
+    exclude group: 'org.apache.logging.log4j', module: 'log4j-core'
+    exclude group: 'org.apache.logging.log4j', module: 'log4j-api'
 }
 
 dependencies {
     implementation 'io.consensys.tuweni:tuweni-bytes'
     implementation 'io.consensys.tuweni:tuweni-units'
     implementation 'org.bouncycastle:bcprov-jdk18on'
-    implementation 'garyschulte:gnark:1.4.1-GRAAL@jar'
-    implementation 'garyschulte:gnark:1.4.1-GRAAL:static@jar'
-    implementation 'garyschulte:secp256k1:1.4.1-GRAAL:static@jar'
+
+    // Use Logback as SLF4J implementation instead of Log4j2
+    implementation 'ch.qos.logback:logback-classic:1.4.14'
+    implementation 'org.hyperledger.besu:gnark:1.4.1-GRAAL@jar'
+    implementation 'org.hyperledger.besu:gnark:1.4.1-GRAAL:static@jar'
+    implementation 'org.hyperledger.besu:secp256k1:1.4.1-GRAAL:static@jar'
     implementation 'org.graalvm.sdk:graal-sdk:24.0.2'
     implementation 'org.hyperledger.besu.internal:besu-crypto-services'
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,5 +1,6 @@
 dependencyManagement {
     imports {
+        //mavenBom "org.hyperledger.besu:bom:{$besuVersion}"
         mavenBom "org.hyperledger.besu:bom:25.9.0"
         mavenBom "org.apache.logging.log4j:log4j-bom:2.24.3"
     }
@@ -11,12 +12,9 @@ dependencies {
     implementation 'org.bouncycastle:bcprov-jdk18on'
     implementation 'garyschulte:gnark:1.4.1-GRAAL@jar'
     implementation 'garyschulte:gnark:1.4.1-GRAAL:static@jar'
+    implementation 'garyschulte:secp256k1:1.4.1-GRAAL:static@jar'
     implementation 'org.graalvm.sdk:graal-sdk:24.0.2'
-
-    // Static libraries for GraalVM native-image
-    implementation('org.hyperledger.besu:gnark:1.4.1-GRAAL:static') {
-        transitive = false
-    }
+    implementation 'org.hyperledger.besu.internal:besu-crypto-services'
 
     errorprone 'com.google.errorprone:error_prone_core:2.35.1'
 }

--- a/src/main/java/org/hyperledger/besu/riscv/poc/NativeImageTestRunner.java
+++ b/src/main/java/org/hyperledger/besu/riscv/poc/NativeImageTestRunner.java
@@ -42,12 +42,17 @@ public class NativeImageTestRunner {
                     runBouncyCastleR1Test();
                     System.out.println();
                     runGnarkG2PointTest();
+                    System.out.println();
+                    runSecp256k1GraalTest();
                     break;
                 case "bouncycastler1":
                     runBouncyCastleR1Test();
                     break;
                 case "gnarkg2point":
                     runGnarkG2PointTest();
+                    break;
+                case "secp256k1graal":
+                    runSecp256k1GraalTest();
                     break;
                 default:
                     System.err.println("Unknown test: " + testName);
@@ -72,11 +77,13 @@ public class NativeImageTestRunner {
         System.out.println("  all              - Run all tests");
         System.out.println("  bouncyCastleR1   - Test BouncyCastle secp256r1 key generation and signing");
         System.out.println("  gnarkG2Point     - Test Gnark BLS12-381 G2 point validation");
+        System.out.println("  secp256k1Graal   - Test SECP256K1 with LibSecp256k1Graal native library");
         System.out.println();
         System.out.println("Examples:");
         System.out.println("  NativeImageTestRunner all");
         System.out.println("  NativeImageTestRunner bouncyCastleR1");
         System.out.println("  NativeImageTestRunner gnarkG2Point");
+        System.out.println("  NativeImageTestRunner secp256k1Graal");
     }
 
     /**
@@ -97,5 +104,15 @@ public class NativeImageTestRunner {
         System.out.println("Gnark BLS12-381 G2 Point Test");
         System.out.println("========================================");
         GnarkG2PointTest.runTest();
+    }
+
+    /**
+     * Runs the SECP256K1 Graal test.
+     */
+    private static void runSecp256k1GraalTest() throws Exception {
+        System.out.println("========================================");
+        System.out.println("SECP256K1 LibSecp256k1Graal Test");
+        System.out.println("========================================");
+        Secp256k1GraalTest.runTest();
     }
 }

--- a/src/main/java/org/hyperledger/besu/riscv/poc/SECP256K1Graal.java
+++ b/src/main/java/org/hyperledger/besu/riscv/poc/SECP256K1Graal.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.hyperledger.besu.riscv.poc;
+
+import org.hyperledger.besu.crypto.AbstractSECP256;
+import org.hyperledger.besu.crypto.KeyPair;
+import org.hyperledger.besu.crypto.SECPPublicKey;
+import org.hyperledger.besu.crypto.SECPSignature;
+import org.hyperledger.besu.nativelib.secp256k1.LibSecp256k1Graal;
+
+import java.math.BigInteger;
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.signers.DSAKCalculator;
+import org.bouncycastle.crypto.signers.HMacDSAKCalculator;
+import org.bouncycastle.math.ec.custom.sec.SecP256K1Curve;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * GraalVM native-image only SECP256K1 implementation.
+ * This class extends AbstractSECP256 and uses LibSecp256k1Graal for verification
+ * and public key recovery operations. Signing uses BouncyCastle as LibSecp256k1Graal
+ * doesn't yet expose the signing function.
+ * This implementation is suitable for GraalVM native-image contexts.
+ */
+public class SECP256K1Graal extends AbstractSECP256 {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SECP256K1Graal.class);
+
+    public static final String CURVE_NAME = "secp256k1";
+
+    /**
+     * Instantiates a new SECP256K1Graal.
+     * This implementation always uses the native library and will throw an exception
+     * if LibSecp256k1Graal is not available.
+     */
+    public SECP256K1Graal() {
+        super(CURVE_NAME, SecP256K1Curve.q);
+
+        if (LibSecp256k1Graal.getContext().isNull()) {
+            throw new RuntimeException("LibSecp256k1Graal native library is not available. " +
+                "This implementation requires GraalVM native-image with statically linked secp256k1.");
+        }
+
+        LOG.info("SECP256K1Graal initialized with native library");
+    }
+
+    @Override
+    public void disableNative() {
+        throw new UnsupportedOperationException(
+            "SECP256K1Graal requires native library and cannot disable it");
+    }
+
+    @Override
+    public boolean maybeEnableNative() {
+        return true;
+    }
+
+    @Override
+    public boolean isNative() {
+        return true;
+    }
+
+    @Override
+    public DSAKCalculator getKCalculator() {
+        return new HMacDSAKCalculator(new SHA256Digest());
+    }
+
+    @Override
+    public String getCurveName() {
+        return CURVE_NAME;
+    }
+
+    @Override
+    public SECPSignature sign(final Bytes32 dataHash, final KeyPair keyPair) {
+        // Use BouncyCastle for signing as LibSecp256k1Graal doesn't yet expose signing
+        return super.sign(dataHash, keyPair);
+    }
+
+    @Override
+    public boolean verify(final Bytes data, final SECPSignature signature, final SECPPublicKey pub) {
+        return verifyNative(data, signature, pub);
+    }
+
+    @Override
+    public Optional<SECPPublicKey> recoverPublicKeyFromSignature(
+        final Bytes32 dataHash, final SECPSignature signature) {
+        Optional<SECPPublicKey> result = recoverFromSignatureNative(dataHash, signature);
+        if (result.isEmpty()) {
+            throw new IllegalArgumentException("Could not recover public key");
+        }
+        return result;
+    }
+
+    @Override
+    protected BigInteger recoverFromSignature(
+        final int recId, final BigInteger r, final BigInteger s, final Bytes32 dataHash) {
+        return recoverFromSignatureNative(dataHash, new SECPSignature(r, s, (byte) recId))
+            .map(key -> new BigInteger(1, key.getEncoded()))
+            .orElse(null);
+    }
+
+    /**
+     * Verify a signature using the native library.
+     *
+     * @param data the data that was signed (typically 32-byte hash)
+     * @param signature the signature to verify
+     * @param pub the public key to verify against
+     * @return true if the signature is valid
+     */
+    private boolean verifyNative(
+        final Bytes data, final SECPSignature signature, final SECPPublicKey pub) {
+        // Parse public key
+        final Bytes encodedPubKey = Bytes.concatenate(Bytes.of(0x04), pub.getEncodedBytes());
+        byte[] pubkeyInternal = new byte[64];
+
+        int parseResult = LibSecp256k1Graal.ecPubkeyParse(
+            LibSecp256k1Graal.getContext(),
+            pubkeyInternal,
+            encodedPubKey.toArrayUnsafe());
+
+        if (parseResult != 1) {
+            throw new IllegalArgumentException("Could not parse public key");
+        }
+
+        // Verify signature (use only r and s, not recovery ID)
+        byte[] compactSignature = signature.encodedBytes().slice(0, 64).toArrayUnsafe();
+        return LibSecp256k1Graal.ecdsaVerify(
+            LibSecp256k1Graal.getContext(),
+            compactSignature,
+            data.toArrayUnsafe(),
+            pubkeyInternal) != 0;
+    }
+
+    /**
+     * Recover a public key from a signature using the native library.
+     *
+     * @param dataHash the 32-byte message hash that was signed
+     * @param signature the signature containing r, s, and recovery id
+     * @return the recovered public key, or empty if recovery failed
+     */
+    private Optional<SECPPublicKey> recoverFromSignatureNative(
+        final Bytes32 dataHash, final SECPSignature signature) {
+        // Use the compact signature + recid version
+        byte[] compactSignature = signature.encodedBytes().slice(0, 64).toArrayUnsafe();
+        int recId = signature.getRecId();
+
+        byte[] recoveredPubkey = LibSecp256k1Graal.ecdsaRecover(
+            LibSecp256k1Graal.getContext(),
+            compactSignature,
+            dataHash.toArrayUnsafe(),
+            recId);
+
+        if (recoveredPubkey == null) {
+            return Optional.empty();
+        }
+
+        // The recovered pubkey is already in internal 64-byte format
+        // Serialize to uncompressed format (65 bytes with 0x04 prefix)
+        byte[] serialized = LibSecp256k1Graal.ecPubkeySerialize(
+            LibSecp256k1Graal.getContext(),
+            recoveredPubkey,
+            false);
+
+        // Remove the 0x04 prefix to get the 64-byte public key
+        return Optional.of(SECPPublicKey.create(Bytes.wrap(serialized).slice(1), ALGORITHM));
+    }
+}

--- a/src/main/java/org/hyperledger/besu/riscv/poc/Secp256k1GraalTest.java
+++ b/src/main/java/org/hyperledger/besu/riscv/poc/Secp256k1GraalTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.hyperledger.besu.riscv.poc;
+
+import org.hyperledger.besu.crypto.KeyPair;
+import org.hyperledger.besu.crypto.SECPPublicKey;
+import org.hyperledger.besu.crypto.SECPSignature;
+
+import java.security.SecureRandom;
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+
+/**
+ * Test case for SECP256K1 using LibSecp256k1Graal native library.
+ * Exercises key generation, signing, verification, and public key recovery
+ * operations in a GraalVM native-image context.
+ */
+public class Secp256k1GraalTest {
+
+    private Secp256k1GraalTest() {}
+
+    /**
+     * Runs the SECP256K1 Graal test suite.
+     *
+     * @throws Exception if cryptographic operations fail
+     */
+    public static void runTest() throws Exception {
+        System.out.println("Initializing SECP256K1Graal...");
+        SECP256K1Graal secp256k1 = new SECP256K1Graal();
+        System.out.println("Native library available: " + secp256k1.isNative());
+        System.out.println();
+
+        // Test 1: Key Generation
+        System.out.println("TEST 1: Key Generation");
+        System.out.println("----------------------");
+        KeyPair keyPair = secp256k1.generateKeyPair();
+        System.out.println("Private key: " + keyPair.getPrivateKey().getEncodedBytes().toHexString());
+        System.out.println("Public key:  " + keyPair.getPublicKey().getEncodedBytes().toHexString());
+        System.out.println("Valid public key: " + secp256k1.isValidPublicKey(keyPair.getPublicKey()));
+        System.out.println();
+
+        // Test 2: Message Signing
+        System.out.println("TEST 2: Message Signing");
+        System.out.println("-----------------------");
+        SecureRandom random = new SecureRandom();
+        byte[] messageHash = new byte[32];
+        random.nextBytes(messageHash);
+        Bytes32 dataHash = Bytes32.wrap(messageHash);
+
+        System.out.println("Message hash: " + dataHash.toHexString());
+
+        SECPSignature signature = secp256k1.sign(dataHash, keyPair);
+        System.out.println("Signature R:  " + Bytes32.leftPad(Bytes.of(signature.getR().toByteArray())).toHexString());
+        System.out.println("Signature S:  " + Bytes32.leftPad(Bytes.of(signature.getS().toByteArray())).toHexString());
+        System.out.println("Recovery ID:  " + signature.getRecId());
+        System.out.println();
+
+        // Test 3: Signature Verification
+        System.out.println("TEST 3: Signature Verification");
+        System.out.println("------------------------------");
+        boolean isValid = secp256k1.verify(dataHash, signature, keyPair.getPublicKey());
+        System.out.println("Signature valid: " + isValid);
+
+        if (!isValid) {
+            throw new RuntimeException("Signature verification failed!");
+        }
+        System.out.println();
+
+        // Test 4: Public Key Recovery
+        System.out.println("TEST 4: Public Key Recovery");
+        System.out.println("---------------------------");
+        Optional<SECPPublicKey> recoveredKey = secp256k1.recoverPublicKeyFromSignature(dataHash, signature);
+
+        if (recoveredKey.isEmpty()) {
+            throw new RuntimeException("Public key recovery failed!");
+        }
+
+        System.out.println("Original public key:  " + keyPair.getPublicKey().getEncodedBytes().toHexString());
+        System.out.println("Recovered public key: " + recoveredKey.get().getEncodedBytes().toHexString());
+        System.out.println("Keys match: " + keyPair.getPublicKey().equals(recoveredKey.get()));
+
+        if (!keyPair.getPublicKey().equals(recoveredKey.get())) {
+            throw new RuntimeException("Recovered public key does not match original!");
+        }
+        System.out.println();
+
+        // Test 5: Invalid Signature Detection
+        System.out.println("TEST 5: Invalid Signature Detection");
+        System.out.println("-----------------------------------");
+        byte[] wrongMessageHash = new byte[32];
+        random.nextBytes(wrongMessageHash);
+        Bytes32 wrongDataHash = Bytes32.wrap(wrongMessageHash);
+
+        boolean invalidSigCheck = secp256k1.verify(wrongDataHash, signature, keyPair.getPublicKey());
+        System.out.println("Wrong message hash: " + wrongDataHash.toHexString());
+        System.out.println("Signature valid for wrong message: " + invalidSigCheck);
+
+        if (invalidSigCheck) {
+            throw new RuntimeException("Invalid signature was incorrectly verified as valid!");
+        }
+        System.out.println();
+
+        // Test 6: Compressed Public Key
+        System.out.println("TEST 6: Compressed Public Key");
+        System.out.println("-----------------------------");
+        Bytes compressedPubKey = secp256k1.compressPublicKey(keyPair.getPublicKey());
+        System.out.println("Uncompressed length: " + keyPair.getPublicKey().getEncodedBytes().size() + " bytes");
+        System.out.println("Compressed length:   " + compressedPubKey.size() + " bytes");
+        System.out.println("Compressed public key: " + compressedPubKey.toHexString());
+        System.out.println();
+
+        System.out.println("All tests completed successfully!");
+    }
+}

--- a/src/main/java/org/hyperledger/besu/riscv/poc/Secp256k1GraalTest.java
+++ b/src/main/java/org/hyperledger/besu/riscv/poc/Secp256k1GraalTest.java
@@ -49,13 +49,14 @@ public class Secp256k1GraalTest {
         System.out.println("TEST 1: Key Generation");
         System.out.println("----------------------");
         KeyPair keyPair = secp256k1.generateKeyPair();
+
         System.out.println("Private key: " + keyPair.getPrivateKey().getEncodedBytes().toHexString());
         System.out.println("Public key:  " + keyPair.getPublicKey().getEncodedBytes().toHexString());
         System.out.println("Valid public key: " + secp256k1.isValidPublicKey(keyPair.getPublicKey()));
         System.out.println();
 
         // Test 2: Message Signing
-        System.out.println("TEST 2: Message Signing");
+        System.out.println("TEST 2: Message Signing (bouncycastle)");
         System.out.println("-----------------------");
         SecureRandom random = new SecureRandom();
         byte[] messageHash = new byte[32];
@@ -65,8 +66,11 @@ public class Secp256k1GraalTest {
         System.out.println("Message hash: " + dataHash.toHexString());
 
         SECPSignature signature = secp256k1.sign(dataHash, keyPair);
-        System.out.println("Signature R:  " + Bytes32.leftPad(Bytes.of(signature.getR().toByteArray())).toHexString());
-        System.out.println("Signature S:  " + Bytes32.leftPad(Bytes.of(signature.getS().toByteArray())).toHexString());
+        // BigInteger.toByteArray() may return 31, 32, or 33 bytes depending on the sign bit
+        Bytes rBytes = Bytes.of(signature.getR().toByteArray());
+        Bytes sBytes = Bytes.of(signature.getS().toByteArray());
+        System.out.println("Signature R:  " + Bytes32.leftPad(rBytes.size() > 32 ? rBytes.slice(1) : rBytes).toHexString());
+        System.out.println("Signature S:  " + Bytes32.leftPad(sBytes.size() > 32 ? sBytes.slice(1) : sBytes).toHexString());
         System.out.println("Recovery ID:  " + signature.getRecId());
         System.out.println();
 

--- a/src/main/resources/META-INF/native-image/org.hyperledger.besu.riscv/besu-zkvm/resource-config.json
+++ b/src/main/resources/META-INF/native-image/org.hyperledger.besu.riscv/besu-zkvm/resource-config.json
@@ -6,6 +6,9 @@
       },
       {
         "pattern": "\\Qorg/bouncycastle/\\E.*"
+      },
+      {
+        "pattern": "\\Qlogback.xml\\E"
       }
     ]
   }

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="OFF" monitorInterval="30">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <!-- Minimal pattern - just message and newline -->
+            <PatternLayout pattern="%m%n" disableAnsi="true"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <!-- Set root level to OFF to disable all logging -->
+        <Root level="OFF">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
add secp256k1 static lib and test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds SECP256K1 Graal native impl with tests, updates native-image to extract/link static libs (incl. secp256k1), and switches logging to Logback.
> 
> - **Crypto / Native**:
>   - `SECP256K1Graal`: new GraalVM-only SECP256K1 impl using `LibSecp256k1Graal` for verify/recover; signing via BouncyCastle.
>   - `Secp256k1GraalTest`: new test suite; `NativeImageTestRunner` gains `secp256k1Graal` option and is included in `all`.
> - **Build / Native Image**:
>   - Replace `extractGnarkNativeLibs` with `extractNativeLibs` to unpack all `*-static.jar` headers/libs into `build/native-libs`.
>   - Add C include flags (`-I`, `-isystem`) and link options for `-lsecp256k1`, `-lgnark_jni`, `-lgnark_eip_196`, `-lgnark_eip_2537`.
>   - Use `JAVA_HOME` GraalVM (remove explicit toolchain), enable `mavenLocal`, and make `build` depend on `nativeCompile`.
> - **Dependencies**:
>   - Switch logging to Logback (`logback-classic`); remove Log4j BOM and exclude Log4j artifacts.
>   - Add `org.hyperledger.besu:gnark` and `:secp256k1` static JARs; include `besu-crypto-services`; add `besuVersion` property.
> - **Resources**:
>   - Include `logback.xml` in native-image resources; add `logback.xml` and `log4j2.xml` configs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 404e4b8e9c64e7b8c86db1bbde29290e2bea1f02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->